### PR TITLE
Update visualize_3D_data.py

### DIFF
--- a/data_helpers/visualize_3D_data.py
+++ b/data_helpers/visualize_3D_data.py
@@ -27,7 +27,7 @@ def plot_growing_cloud(datasetname, scene, data_root):
     rotations = np.array(rotations)
     poses = np.concatenate([locations, rotations], 1)
 
-    r = R.from_quat(rotations).as_dcm()
+    r = R.from_quat(rotations).as_matrix()
 
     TM = np.eye(4)
     TM[1, 1] = -1


### PR DESCRIPTION
"as_dcm" has been replaced with  "as_matrix" in Scipy. Link to the change: https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.Rotation.from_matrix.html